### PR TITLE
Add ZIP-321 Parsing support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Unreleased
+
+### Added 
+- ZIP321 enum now has `ParserResult`
+```
+sealed class ParserResult {
+        data class SingleAddress(val singleRecipient: RecipientAddress): ParserResult()
+
+        data class Request(val paymentRequest: PaymentRequest): ParserResult()
+    }
+```
+
+- `fun request(uriString: String, validatingRecipients: ((String) -> Boolean)?): ParserResult`
+- `MemoBytes` now supports `fun fromBase64URL(string: String): MemoBytes`
+
+### modified
+- `Amount` was changed to `NonNegativeAmount`
+
 
 ## [0.0.1] - 2023-11-27
 

--- a/README.md
+++ b/README.md
@@ -16,22 +16,21 @@ can be parsed by several applications across the ecosystem
 
 ## Project Roadmap
 
-### 1. ZIP-321 construction
+### 1. ZIP-321 construction ✅
 
 - Provide an API that lets users build a Payment Request URI from its bare-bone components. ✅
 - There's a comprehensive set of tests that exercises the logic above according with what is defined on [ZIP-321](https://zips.z.cash/zip-0321) ✅
 - (Optional) Mechanism for callers to provide logic for validating of Zcash addresses ✅
 
-
-### 2. ZIP-321 built-in validation
-- Built-in mechanism to validate the provided input. This will entail leveraging some sort of FFI calls to [`zcash_address` crate](https://crates.io/crates/zcash_address/0.1.0)
-
-### 3. ZIP-321 parsing
-- Given a valid ZIP-321 Payment Request, initializer a swift struct that represents the given URI.
+### 2. ZIP-321 parsing ✅
+- Given a valid ZIP-321 Payment Request String, create a PaymentRequest Object ✅
 - The result of the point above would have to be equivalent as if the given URI was generated programmatically with the same inputs using the API of `1.` of the roadmap
 - The parser API uses `2.` of the roadmap to validate the provided ZIP-321 Request
 - The parser checks the integrity of the provided URI as defined on [ZIP-321](https://zips.z.cash/zip-0321)
 - There's a comprehensive set of Unit Tests that exercise the point above.
+
+### 3. ZIP-321 built-in validation
+- Built-in mechanism to validate the provided input. This will entail leveraging some sort of FFI calls to [`zcash_address` crate](https://crates.io/crates/zcash_address/0.1.0)
 
 ## Getting Started
 
@@ -106,5 +105,29 @@ val paymentRequest = PaymentRequest(payments = listOf(payment0, payment1))
 
 ZIP321.uriString(paymentRequest, ZIP321.FormattingOptions.UseEmptyParamIndex(omitAddressLabel = false))
 ````
+
+### Parsing a ZIP-321 URI String 
+
+```Kotlin
+val validURI =
+            "zcash:?address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU&amount=123.456&address.1=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amount.1=0.789&memo.1=VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok"
+
+ val paymentRequest = ZIP321.request(validURI, null)
+```
+
+### Providing Address validation
+
+Address validation is not provided by the library. The only thing it's bundled is a rudimentary way to
+detect possible transparent addresses in recipients to actually throw an error to ZIP-321 specs.
+
+if you have a zcash wallet app, you most likely have methods to validate that a given string is a 
+valid Zcash address. In that case you should call the parsing method with a lambda 
+
+```
+val paymentRequest = ZIP321.request(validURI, { ZcashSDK.isValidAddress(it) })
+```
+
+Errors will be thrown if such validation fails.
+
 # License
 This project is under MIT License. See [LICENSE.md](LICENSE.md) for more details.

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
 
     // Use Detekt
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.3")
+
+    // parser
+    implementation("io.github.copper-leaf:kudzu-core:5.1.0")
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api("org.apache.commons:commons-math3:3.6.1")
 
@@ -41,7 +44,11 @@ detekt {
     buildUponDefaultConfig = true // preconfigure defaults
     allRules = false // activate all available (even unstable) rules.
     config.setFrom("$rootDir/tools/detekt.yml")
-    autoCorrect = false
+    autoCorrect = true
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    exclude("$rootDir/lib/src/test")
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/Render.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/Render.kt
@@ -1,7 +1,7 @@
 package dev.thecodebuffet.zcash.zip321
 
-import Amount
 import MemoBytes
+import NonNegativeAmount
 import Payment
 import PaymentRequest
 import RecipientAddress
@@ -25,8 +25,8 @@ object Render {
         return "$label${parameterIndex(index)}=$qcharValue"
     }
 
-    fun parameter(amount: Amount, index: UInt?): String {
-        return "${ParamName.AMOUNT.value}${parameterIndex(index)}=$amount"
+    fun parameter(nonNegativeAmount: NonNegativeAmount, index: UInt?): String {
+        return "${ParamName.AMOUNT.value}${parameterIndex(index)}=$nonNegativeAmount"
     }
 
     fun parameter(memo: MemoBytes, index: UInt?): String {
@@ -60,7 +60,7 @@ object Render {
             result += "&"
         }
 
-        result += "${parameter(payment.amount, index)}"
+        result += "${parameter(payment.nonNegativeAmount, index)}"
 
         payment.memo?.let { result += "&${parameter(it, index)}" }
         payment.label?.let { result += "&${parameterLabel(label = it, index)}" }

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/extensions/StringEncodings.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/extensions/StringEncodings.kt
@@ -15,3 +15,7 @@ fun String.qcharEncoded(): String? {
         }
     }
 }
+
+fun String.qcharDecode(): String? {
+    return java.net.URLDecoder.decode(this, "UTF-8")
+}

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/model/NonNegativeAmount.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/model/NonNegativeAmount.kt
@@ -7,7 +7,7 @@ import java.math.RoundingMode
  *
  * @property value The decimal value of the ZEC amount.
  */
-class Amount {
+class NonNegativeAmount {
     private val value: BigDecimal
 
     /**
@@ -70,8 +70,8 @@ class Amount {
          * non-negative non-zero ZEC decimal amount.
          */
         @Throws(AmountError::class)
-        fun create(value: BigDecimal): Amount {
-            return Amount(value.round())
+        fun create(value: BigDecimal): NonNegativeAmount {
+            return NonNegativeAmount(value.round())
         }
 
         /**
@@ -83,7 +83,7 @@ class Amount {
          * amount constraints.
          */
         @Throws(AmountError::class)
-        fun createFromString(string: String): Amount {
+        fun createFromString(string: String): NonNegativeAmount {
             return create(decimalFromString(string))
         }
 
@@ -114,5 +114,20 @@ class Amount {
      */
     override fun toString(): String {
         return value.setScale(maxFractionalDecimalDigits, RoundingMode.HALF_EVEN).stripTrailingZeros().toPlainString()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NonNegativeAmount
+
+        // NOTE: comparing with == operator provides false negatives.
+        // apparently this is a JDK issue.
+        return this.value.compareTo(other.value) == 0
+    }
+
+    override fun hashCode(): Int {
+        return 31 * this.value.hashCode()
     }
 }

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/model/Payment.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/model/Payment.kt
@@ -1,8 +1,38 @@
+
 data class Payment(
     val recipientAddress: RecipientAddress,
-    val amount: Amount,
+    val nonNegativeAmount: NonNegativeAmount,
     val memo: MemoBytes?,
     val label: String?,
     val message: String?,
-    val otherParams: List<RequestParams>?
-)
+    val otherParams: List<OtherParam>?
+) {
+    @Suppress("EmptyClassBlock")
+    companion object {}
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Payment) return false
+
+        if (recipientAddress != other.recipientAddress) return false
+        if (nonNegativeAmount != other.nonNegativeAmount) return false
+        if (memo != other.memo) return false
+        if (label != other.label) return false
+        if (message != other.message) return false
+        if (otherParams != other.otherParams) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = recipientAddress.hashCode()
+        result = 31 * result + nonNegativeAmount.hashCode()
+        result = 31 * result + (memo?.hashCode() ?: 0)
+        result = 31 * result + (label?.hashCode() ?: 0)
+        result = 31 * result + (message?.hashCode() ?: 0)
+        result = 31 * result + (otherParams?.hashCode() ?: 0)
+        return result
+    }
+}
+
+data class OtherParam(val key: String, val value: String)

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/model/RecipientAddress.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/model/RecipientAddress.kt
@@ -20,4 +20,19 @@ class RecipientAddress private constructor(val value: String) {
             false -> throw RecipientAddressError.InvalidRecipient
         }
     )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RecipientAddress) return false
+
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    fun isTransparent(): Boolean {
+        return value.startsWith("t")
+    }
 }

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/AddressParser.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/AddressParser.kt
@@ -1,0 +1,10 @@
+package dev.thecodebuffet.zcash.zip321.parser
+
+import com.copperleaf.kudzu.parser.text.BaseTextParser
+
+class AddressTextParser : BaseTextParser(
+    isValidChar = { _, char -> char.isLetterOrDigit() },
+    isValidText = { it.isNotEmpty() },
+    allowEmptyInput = false,
+    invalidTextErrorMessage = { "Expected bech32 or Base58 text, got '$it'" }
+)

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/CharsetValidations.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/CharsetValidations.kt
@@ -1,0 +1,80 @@
+package dev.thecodebuffet.zcash.zip321.parser
+
+class CharsetValidations {
+    companion object {
+        object Base58CharacterSet {
+            val characters: Set<Char> = setOf(
+                '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K',
+                'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+                'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                'g', 'h', 'i', 'j', 'k', 'm', 'n', 'o', 'p', 'q',
+                'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+            )
+        }
+
+        object Bech32CharacterSet {
+            val characters: Set<Char> = setOf(
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+                'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
+                'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
+            )
+        }
+
+        object ParamNameCharacterSet {
+            val characters: Set<Char> = setOf(
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+                'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+                'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
+                'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+                'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
+                'y', 'z', '+', '-'
+            )
+        }
+
+        object UnreservedCharacterSet {
+            val characters = setOf(
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+                'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '.', '_', '~', '!'
+            )
+        }
+
+        object PctEncodedCharacterSet {
+            val characters = setOf(
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F',
+                'a', 'b', 'c', 'd', 'e', 'f', '%'
+            )
+        }
+
+        object AllowedDelimsCharacterSet {
+            val characters = setOf('!', '$', '\'', '(', ')', '*', '+', ',', ';')
+        }
+
+        object QcharCharacterSet {
+            val characters = UnreservedCharacterSet.characters.union(
+                PctEncodedCharacterSet.characters
+            )
+                .union(
+                    AllowedDelimsCharacterSet.characters
+                )
+                .union(
+                    setOf(':', '@')
+                )
+        }
+
+        val isValidBase58OrBech32Char: (Char) -> Boolean = { char ->
+            isValidBase58Char(char) || isValidBech32Char(char)
+        }
+
+        val isValidBase58Char: (Char) -> Boolean = { it in Base58CharacterSet.characters }
+
+        val isValidBech32Char: (Char) -> Boolean = { it in Bech32CharacterSet.characters }
+
+        val isValidParamNameChar: (Char) -> Boolean = { it in ParamNameCharacterSet.characters }
+    }
+}

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/IndexedParameter.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/IndexedParameter.kt
@@ -1,0 +1,24 @@
+package dev.thecodebuffet.zcash.zip321.parser
+
+data class IndexedParameter(
+    val index: UInt,
+    val param: Param
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as IndexedParameter
+
+        if (index != other.index) return false
+        if (param != other.param) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = index.hashCode()
+        result = 31 * result + param.hashCode()
+        return result
+    }
+}

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/Param.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/Param.kt
@@ -1,0 +1,158 @@
+package dev.thecodebuffet.zcash.zip321.parser
+
+import MemoBytes
+import NonNegativeAmount
+import RecipientAddress
+import dev.thecodebuffet.zcash.zip321.ParamName
+import dev.thecodebuffet.zcash.zip321.ZIP321
+import dev.thecodebuffet.zcash.zip321.extensions.qcharDecode
+
+sealed class Param {
+    companion object {
+        fun from(
+            queryKey: String,
+            value: String,
+            index: UInt,
+            validatingAddress: ((String) -> Boolean)? = null
+        ): Param {
+            return when (queryKey) {
+                ParamName.ADDRESS.value -> {
+                    try {
+                        Param.Address(RecipientAddress(value, validatingAddress))
+                    } catch (error: RecipientAddress.RecipientAddressError.InvalidRecipient) {
+                        throw ZIP321.Errors.InvalidAddress(if (index > 0u) index else null)
+                    }
+                }
+                ParamName.AMOUNT.value -> {
+                    try {
+                        Param.Amount(NonNegativeAmount(decimalString = value))
+                    } catch (error: NonNegativeAmount.AmountError.NegativeAmount) {
+                        throw ZIP321.Errors.AmountTooSmall(index)
+                    } catch (error: NonNegativeAmount.AmountError.GreaterThanSupply) {
+                        throw ZIP321.Errors.AmountExceededSupply(index)
+                    } catch (error: NonNegativeAmount.AmountError.InvalidTextInput) {
+                        throw ZIP321.Errors.ParseError("Invalid text input $value")
+                    } catch (error: NonNegativeAmount.AmountError.TooManyFractionalDigits) {
+                        throw ZIP321.Errors.AmountTooSmall(index)
+                    }
+                }
+                ParamName.LABEL.value -> {
+                    when (val qcharDecoded = value.qcharDecode()) {
+                        null -> throw ZIP321.Errors.QcharDecodeFailed(index.mapToParamIndex(), queryKey, value)
+                        else -> Param.Label(qcharDecoded)
+                    }
+                }
+                ParamName.MESSAGE.value -> {
+                    when (val qcharDecoded = value.qcharDecode()) {
+                        null -> throw ZIP321.Errors.QcharDecodeFailed(index.mapToParamIndex(), queryKey, value)
+                        else -> Param.Message(qcharDecoded)
+                    }
+                }
+                ParamName.MEMO.value -> {
+                    try {
+                        Param.Memo(MemoBytes.fromBase64URL(value))
+                    } catch (error: MemoBytes.MemoError) {
+                        throw ZIP321.Errors.MemoBytesError(error, index)
+                    }
+                }
+                else -> {
+                    if (queryKey.startsWith("req-")) {
+                        throw ZIP321.Errors.UnknownRequiredParameter(queryKey)
+                    }
+
+                    when (val qcharDecoded = value.qcharDecode()) {
+                        null -> throw ZIP321.Errors.InvalidParamValue("message", index)
+                        else -> Param.Other(queryKey, qcharDecoded)
+                    }
+                }
+            }
+        }
+    }
+
+    data class Address(val recipientAddress: RecipientAddress) : Param()
+    data class Amount(val amount: NonNegativeAmount) : Param()
+    data class Memo(val memoBytes: MemoBytes) : Param()
+    data class Label(val label: String) : Param()
+    data class Message(val message: String) : Param()
+    data class Other(val paramName: String, val value: String) : Param()
+
+    val name: String
+        get() = when (this) {
+            is Address -> ParamName.ADDRESS.name.lowercase()
+            is Amount -> ParamName.AMOUNT.name.lowercase()
+            is Memo -> ParamName.MEMO.name.lowercase()
+            is Label -> ParamName.LABEL.name.lowercase()
+            is Message -> ParamName.MESSAGE.name.lowercase()
+            is Other -> paramName
+        }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Param
+
+        if (name != other.name) return false
+
+        return when (this) {
+            is Address -> recipientAddress == (other as? Address)?.recipientAddress
+            is Amount -> amount == (other as? Amount)?.amount
+            is Memo -> memoBytes == (other as? Memo)?.memoBytes
+            is Label -> label == (other as? Label)?.label
+            is Message -> message == (other as? Message)?.message
+            is Other -> (other as? Other)?.let {
+                    p ->
+                p.paramName == paramName && p.value == value
+            } ?: false
+        }
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + when (this) {
+            is Address -> recipientAddress.hashCode()
+            is Amount -> amount.hashCode()
+            is Memo -> memoBytes.hashCode()
+            is Label -> label.hashCode()
+            is Message -> message.hashCode()
+            is Other -> {
+                result = 31 * result + paramName.hashCode()
+                result = 31 * result + value.hashCode()
+                result
+            }
+        }
+        return result
+    }
+
+    /**
+     * Checks if this `Param` is the same kind of
+     * the other given regardless of the value.
+     * this is useful to check if a list of `Param`
+     * conforming a `Payment` has duplicate query keys
+     * telling the porser to fail.
+     */
+    fun partiallyEqual(other: Param): Boolean {
+        if (this === other) return true
+
+        if (name != other.name) return false
+
+        return when (this) {
+            is Address -> (other as? Address) != null
+            is Amount -> (other as? Amount) != null
+            is Memo -> (other as? Memo) != null
+            is Label -> (other as? Label) != null
+            is Message -> (other as? Message) != null
+            is Other -> (other as? Other)?.let {
+                    p ->
+                p.paramName == paramName
+            } ?: false
+        }
+    }
+}
+
+fun List<Param>.hasDuplicateParam(param: Param): Boolean {
+    for (i in this) {
+        if (i.partiallyEqual(param)) return true else continue
+    }
+    return false
+}

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/ParameterNameParser.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/ParameterNameParser.kt
@@ -1,0 +1,17 @@
+
+package dev.thecodebuffet.zcash.zip321.parser
+
+import com.copperleaf.kudzu.parser.text.BaseTextParser
+
+class ParameterNameParser : BaseTextParser(
+    isValidChar = { _, char -> CharsetValidations.isValidParamNameChar(char) },
+    isValidText = {
+        it.isNotEmpty() &&
+            it.all {
+                    c ->
+                CharsetValidations.isValidParamNameChar(c)
+            }
+    },
+    allowEmptyInput = false,
+    invalidTextErrorMessage = { "Expected [A-Za-z0-9+-], got '$it'" }
+)

--- a/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/Parser.kt
+++ b/lib/src/main/kotlin/dev/thecodebuffet/zcash/zip321/parser/Parser.kt
@@ -1,0 +1,309 @@
+
+package dev.thecodebuffet.zcash.zip321.parser
+
+import MemoBytes
+import NonNegativeAmount
+import OtherParam
+import Payment
+import PaymentRequest
+import RecipientAddress
+import com.copperleaf.kudzu.parser.ParserContext
+import com.copperleaf.kudzu.parser.chars.AnyCharParser
+import com.copperleaf.kudzu.parser.chars.CharInParser
+import com.copperleaf.kudzu.parser.chars.DigitParser
+import com.copperleaf.kudzu.parser.choice.PredictiveChoiceParser
+import com.copperleaf.kudzu.parser.many.ManyParser
+import com.copperleaf.kudzu.parser.many.SeparatedByParser
+import com.copperleaf.kudzu.parser.many.UntilParser
+import com.copperleaf.kudzu.parser.mapped.MappedParser
+import com.copperleaf.kudzu.parser.maybe.MaybeParser
+import com.copperleaf.kudzu.parser.sequence.SequenceParser
+import com.copperleaf.kudzu.parser.text.LiteralTokenParser
+import dev.thecodebuffet.zcash.zip321.ZIP321
+import dev.thecodebuffet.zcash.zip321.ZIP321.ParserResult
+import java.math.BigDecimal
+
+class Parser(private val addressValidation: ((String) -> Boolean)?) {
+    val maybeLeadingAddressParse = MappedParser(
+        SequenceParser(
+            LiteralTokenParser("zcash:"),
+            MaybeParser(
+                AddressTextParser()
+            )
+        )
+    ) {
+        val addressValue: IndexedParameter? = it.node2.node?.let { textNode ->
+
+            IndexedParameter(
+                index = 0u,
+                param = Param.Address(
+                    RecipientAddress(
+                        textNode.text,
+                        validating = addressValidation
+                    )
+                )
+            )
+        }
+        addressValue
+    }
+
+    val parameterIndexParser = MappedParser(
+        SequenceParser(
+            CharInParser(CharRange('1', '9')),
+            MaybeParser(
+                ManyParser(
+                    DigitParser()
+                )
+            )
+        )
+    ) {
+        val firstDigit = it.node1.text
+
+        (
+            firstDigit + it.node2.let { node ->
+                if (node.text.length > 3) {
+                    throw ZIP321.Errors.InvalidParamIndex(firstDigit + node.text)
+                } else {
+                    node.text
+                }
+            }
+            ).toUInt()
+    }
+
+    val optionallyIndexedParamName = MappedParser(
+        SequenceParser(
+            UntilParser(
+                AnyCharParser(),
+                PredictiveChoiceParser(
+                    LiteralTokenParser("."),
+                    LiteralTokenParser("=")
+                )
+            ),
+            MaybeParser(
+                SequenceParser(
+                    LiteralTokenParser("."),
+                    parameterIndexParser
+                )
+            )
+        )
+    ) {
+        val paramName = it.node1.text
+
+        if (!paramName.all { c -> CharsetValidations.isValidParamNameChar(c) }) {
+            throw ZIP321.Errors.ParseError("Invalid paramname $paramName")
+        } else {
+            Pair<String, UInt?>(
+                it.node1.text,
+                it.node2.node?.node2?.value
+            )
+        }
+    }
+
+    val queryKeyAndValueParser = MappedParser(
+        SequenceParser(
+            optionallyIndexedParamName,
+            LiteralTokenParser("="),
+            ManyParser(
+                CharInParser(CharsetValidations.Companion.QcharCharacterSet.characters.toList())
+            )
+        )
+    ) {
+        Pair(it.node1.value, it.node3.text)
+    }
+
+    /**
+     * parses a sequence of query parameters lead by query separator char (?)
+     */
+    private val queryParamsParser = MappedParser(
+        SequenceParser(
+            LiteralTokenParser("?"),
+            SeparatedByParser(
+                queryKeyAndValueParser,
+                LiteralTokenParser("&")
+            )
+        )
+    ) {
+        it.node2.nodeList.map { node -> node.value }
+    }
+
+    /**
+     * maps a parsed Query Parameter key and value into an `IndexedParameter`
+     * providing validation of Query keys and values. An address validation can be provided.
+     */
+    fun zcashParameter(
+        parsedQueryKeyValue: Pair<Pair<String, UInt?>, String>,
+        validatingAddress: ((String) -> Boolean)? = null
+    ): IndexedParameter {
+        val queryKey = parsedQueryKeyValue.first.first
+        val queryKeyIndex = parsedQueryKeyValue.first.second?.let {
+            if (it == 0u) {
+                throw ZIP321.Errors.InvalidParamIndex("$queryKey.0")
+            } else {
+                it
+            }
+        } ?: 0u
+        val queryValue = parsedQueryKeyValue.second
+
+        val param = Param.from(
+            queryKey,
+            queryValue,
+            queryKeyIndex,
+            validatingAddress
+        )
+
+        return IndexedParameter(queryKeyIndex, param)
+    }
+
+    /**
+     * Parses the rest of the URI after the `zcash:` and possible
+     * leading address have been captured, validating the found addresses
+     * if validation is provided
+     */
+    fun parseParameters(
+        remainingString: ParserContext,
+        leadingAddress: IndexedParameter?,
+        validatingAddress: ((String) -> Boolean)? = null
+    ): List<IndexedParameter> {
+        val list = ArrayList<IndexedParameter>()
+
+        leadingAddress?.let { list.add(it) }
+
+        list.addAll(
+            queryParamsParser.parse(remainingString)
+                .first
+                .value
+                .map { zcashParameter(it, validatingAddress) }
+        )
+
+        if (list.isEmpty()) {
+            throw ZIP321.Errors.RecipientMissing(null)
+        }
+
+        return list
+    }
+
+    /**
+     * Maps a list of `IndexedParameter` into a list of validated `Payment`
+     */
+    @Throws(ZIP321.Errors::class)
+    fun mapToPayments(indexedParameters: List<IndexedParameter>): List<Payment> {
+        if (indexedParameters.isEmpty()) {
+            throw ZIP321.Errors.RecipientMissing(null)
+        }
+
+        val paramsByIndex: MutableMap<UInt, MutableList<Param>> = mutableMapOf()
+
+        for (idxParam in indexedParameters) {
+            val paramVecByIndex = paramsByIndex[idxParam.index]
+            if (paramVecByIndex != null) {
+                if (paramVecByIndex.hasDuplicateParam(idxParam.param)) {
+                    throw ZIP321.Errors.DuplicateParameter(
+                        idxParam.param.name,
+                        idxParam.index.mapToParamIndex()
+                    )
+                } else {
+                    paramVecByIndex.add(idxParam.param)
+                }
+            } else {
+                paramsByIndex[idxParam.index] = mutableListOf(idxParam.param)
+            }
+        }
+
+        return paramsByIndex
+            .map { (index, parameters) ->
+                Payment.fromUniqueIndexedParameters(index, parameters)
+            }
+    }
+
+    @Throws(ZIP321.Errors::class)
+    fun parse(uriString: String): ParserResult {
+        val (node, remainingText) = maybeLeadingAddressParse.parse(
+            ParserContext.fromString(uriString)
+        )
+
+        val leadingAddress = node.value
+
+        // no remaining text to parse and no address found. Not a valid URI
+        if (remainingText.isEmpty() && leadingAddress == null) {
+            throw ZIP321.Errors.InvalidURI
+        }
+
+        if (remainingText.isEmpty() && leadingAddress != null) {
+            leadingAddress?.let {
+                when (val param = it.param) {
+                    is Param.Address -> return ParserResult.SingleAddress(param.recipientAddress)
+                    else ->
+                        throw ZIP321.Errors.ParseError(
+                            "leading parameter after `zcash:` that is not an address"
+                        )
+                }
+            }
+        }
+
+        // remaining text is not empty there's still work to do
+        return ParserResult.Request(
+            PaymentRequest(
+                mapToPayments(
+                    parseParameters(remainingText, node.value, addressValidation)
+                )
+            )
+        )
+    }
+}
+
+@Suppress("detekt:CyclomaticComplexMethod")
+fun Payment.Companion.fromUniqueIndexedParameters(index: UInt, parameters: List<Param>): Payment {
+    val recipient = parameters.firstOrNull { param ->
+        when (param) {
+            is Param.Address -> true
+            else -> false
+        }
+    }?.let { address ->
+        when (address) {
+            is Param.Address -> address.recipientAddress
+            else -> null
+        }
+    } ?: throw ZIP321.Errors.RecipientMissing(index.mapToParamIndex())
+
+    var amount: NonNegativeAmount? = null
+    var memo: MemoBytes? = null
+    var label: String? = null
+    var message: String? = null
+    val other = ArrayList<OtherParam>()
+
+    for (param in parameters) {
+        when (param) {
+            is Param.Address -> continue
+            is Param.Amount -> amount = param.amount
+            is Param.Label -> label = param.label
+            is Param.Memo -> {
+                if (recipient.isTransparent()) {
+                    throw ZIP321.Errors.TransparentMemoNotAllowed(index.mapToParamIndex())
+                }
+
+                memo = param.memoBytes
+            }
+            is Param.Message -> message = param.message
+            is Param.Other -> other.add(OtherParam(param.paramName, param.value))
+        }
+    }
+
+    return Payment(
+        recipient,
+        amount ?: NonNegativeAmount(BigDecimal(0)),
+        memo,
+        label,
+        message,
+        when (other.isEmpty()) {
+            true -> null
+            false -> other
+        }
+    )
+}
+
+fun UInt.mapToParamIndex(): UInt? {
+    return when (this == 0u) {
+        false -> this
+        true -> null
+    }
+}

--- a/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/AmountTests.kt
+++ b/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/AmountTests.kt
@@ -1,6 +1,6 @@
 package dev.thecodebuffet.zcash.zip321
 
-import Amount
+import NonNegativeAmount
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -9,48 +9,48 @@ import java.math.BigDecimal
 class AmountTests : FreeSpec({
     "Amount tests" - {
         "testAmountStringDecimals" {
-            Amount(BigDecimal("123.456")).toString() shouldBe "123.456"
-            "${Amount(BigDecimal("123.456"))}" shouldBe "123.456"
+            NonNegativeAmount(BigDecimal("123.456")).toString() shouldBe "123.456"
+            "${NonNegativeAmount(BigDecimal("123.456"))}" shouldBe "123.456"
         }
 
         "testAmountTrailing" {
-            Amount(BigDecimal("50.000")).toString() shouldBe "50"
+            NonNegativeAmount(BigDecimal("50.000")).toString() shouldBe "50"
         }
 
         "testAmountLeadingZeros" {
-            Amount(BigDecimal("0000.5")).toString() shouldBe "0.5"
+            NonNegativeAmount(BigDecimal("0000.5")).toString() shouldBe "0.5"
         }
 
         "testAmountMaxDecimals" {
-            Amount(BigDecimal("0.12345678")).toString() shouldBe "0.12345678"
+            NonNegativeAmount(BigDecimal("0.12345678")).toString() shouldBe "0.12345678"
         }
 
         "testAmountThrowsIfMaxSupply" {
-            shouldThrow<Amount.AmountError> {
-                Amount(BigDecimal("21000000.00000001")).toString()
+            shouldThrow<NonNegativeAmount.AmountError> {
+                NonNegativeAmount(BigDecimal("21000000.00000001")).toString()
             }
         }
 
         "testAmountThrowsIfNegativeAmount" {
-            shouldThrow<Amount.AmountError> {
-                Amount(BigDecimal("-1")).toString()
+            shouldThrow<NonNegativeAmount.AmountError> {
+                NonNegativeAmount(BigDecimal("-1")).toString()
             }
         }
 
         // Text Conversion Tests
 
         "testAmountThrowsIfTooManyFractionalDigits" {
-            shouldThrow<Amount.AmountError.TooManyFractionalDigits> {
-                Amount("0.123456789")
+            shouldThrow<NonNegativeAmount.AmountError.TooManyFractionalDigits> {
+                NonNegativeAmount("0.123456789")
             }
         }
 
         "testAmountParsesMaxFractionalDigits" {
-            Amount("0.12345678").toString() shouldBe Amount(BigDecimal("0.12345678")).toString()
+            NonNegativeAmount("0.12345678").toString() shouldBe NonNegativeAmount(BigDecimal("0.12345678")).toString()
         }
 
         "testAmountParsesMaxAmount" {
-            Amount("21000000").toString() shouldBe Amount(BigDecimal("21000000")).toString()
+            NonNegativeAmount("21000000").toString() shouldBe NonNegativeAmount(BigDecimal("21000000")).toString()
         }
     }
 })

--- a/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/EncodingTests.kt
+++ b/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/EncodingTests.kt
@@ -1,5 +1,6 @@
 package dev.thecodebuffet.zcash.zip321
 
+import dev.thecodebuffet.zcash.zip321.extensions.qcharDecode
 import dev.thecodebuffet.zcash.zip321.extensions.qcharEncoded
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
@@ -59,6 +60,36 @@ class EncodingTests : FunSpec({
             qcharEncoded should {
                 it != null && it.contains("%")
             }
+        }
+    }
+
+    test("qcharEncodedText decodes properly") {
+        mapOf(
+            "Thank%20you%20for%20your%20purchase" to "Thank you for your purchase",
+            "Use%20Coupon%20%5BZEC4LIFE%5D%20to%20get%20a%2020%25%20discount%20on%20your%20next%20purchase!!" to
+                "Use Coupon [ZEC4LIFE] to get a 20% discount on your next purchase!!",
+            "Order%20%23321" to "Order #321",
+            "Your%20Ben%20%26%20Jerry's%20Order" to "Your Ben & Jerry's Order",
+            "%20" to " ",
+            "%22" to "\"",
+            "%23" to "#",
+            "%25" to "%",
+            "%26" to "&",
+            "%2F" to "/",
+            "%3C" to "<",
+            "%3D" to "=",
+            "%3E" to ">",
+            "%3F" to "?",
+            "%5B" to "[",
+            "%5C" to "\\",
+            "%5D" to "]",
+            "%5E" to "^",
+            "%60" to "`",
+            "%7B" to "{",
+            "%7C" to "|",
+            "%7D" to "}"
+        ).forEach { (input, expected) ->
+            input.qcharDecode() shouldBe expected
         }
     }
 })

--- a/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/MemoBytesTests.kt
+++ b/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/MemoBytesTests.kt
@@ -29,6 +29,10 @@ class MemoBytesTests : FunSpec({
 
         val memo = MemoBytes(memoUTF8Text)
         memo.toBase64URL() shouldBe expectedBase64
+
+        MemoBytes.fromBase64URL(expectedBase64).data.contentEquals(memo.data) shouldBe true
+
+        MemoBytes.fromBase64URL(expectedBase64).equals(memo) shouldBe true
     }
 
     test("InitWithStringThrows") {

--- a/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/RendererTests.kt
+++ b/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/RendererTests.kt
@@ -1,7 +1,7 @@
 package dev.thecodebuffet.zcash.zip321
 
-import Amount
 import MemoBytes
+import NonNegativeAmount
 import Payment
 import RecipientAddress
 import io.kotest.core.spec.style.FreeSpec
@@ -11,14 +11,14 @@ class RendererTests : FreeSpec({
     "Amount Tests" - {
         "Amount parameter is rendered with no `paramIndex`" {
             val expected = "amount=123.456"
-            val amount = Amount(123.456.toBigDecimal())
-            Render.parameter(amount, null) shouldBe expected
+            val nonNegativeAmount = NonNegativeAmount(123.456.toBigDecimal())
+            Render.parameter(nonNegativeAmount, null) shouldBe expected
         }
 
         "Amount parameter is rendered with `paramIndex`" {
             val expected = "amount.1=123.456"
-            val amount = Amount(123.456.toBigDecimal())
-            Render.parameter(amount, 1u) shouldBe expected
+            val nonNegativeAmount = NonNegativeAmount(123.456.toBigDecimal())
+            Render.parameter(nonNegativeAmount, 1u) shouldBe expected
         }
 
         "Address parameter is rendered with no `paramIndex`" {
@@ -88,7 +88,7 @@ class RendererTests : FreeSpec({
             val recipient0 = RecipientAddress(value = address0)
             val payment0 = Payment(
                 recipientAddress = recipient0,
-                amount = Amount(123.456.toBigDecimal()),
+                nonNegativeAmount = NonNegativeAmount(123.456.toBigDecimal()),
                 memo = null,
                 label = null,
                 message = null,
@@ -106,7 +106,7 @@ class RendererTests : FreeSpec({
             val recipient1 = RecipientAddress(value = address1)
             val payment1 = Payment(
                 recipientAddress = recipient1,
-                amount = Amount(0.789.toBigDecimal()),
+                nonNegativeAmount = NonNegativeAmount(0.789.toBigDecimal()),
                 memo = MemoBytes("This is a unicode memo ✨🦄🏆🎉"),
                 label = null,
                 message = null,
@@ -123,7 +123,7 @@ class RendererTests : FreeSpec({
             val recipient0 = RecipientAddress(value = address0)
             val payment0 = Payment(
                 recipientAddress = recipient0,
-                amount = Amount(123.456.toBigDecimal()),
+                nonNegativeAmount = NonNegativeAmount(123.456.toBigDecimal()),
                 memo = null,
                 label = null,
                 message = null,
@@ -141,7 +141,7 @@ class RendererTests : FreeSpec({
             val recipient1 = RecipientAddress(value = address1)
             val payment1 = Payment(
                 recipientAddress = recipient1,
-                amount = Amount(0.789.toBigDecimal()),
+                nonNegativeAmount = NonNegativeAmount(0.789.toBigDecimal()),
                 memo = MemoBytes("This is a unicode memo ✨🦄🏆🎉"),
                 label = null,
                 message = null,

--- a/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/ZcashSwiftPaymentUriTests.kt
+++ b/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/ZcashSwiftPaymentUriTests.kt
@@ -1,10 +1,11 @@
 package dev.thecodebuffet.zcash.zip321
 
-import Amount
 import MemoBytes
+import NonNegativeAmount
 import Payment
 import PaymentRequest
 import RecipientAddress
+import io.kotest.assertions.fail
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
@@ -15,7 +16,8 @@ class ZcashSwiftPaymentUriTests : FreeSpec({
     "test that a single recipient payment request is generated" {
         val expected =
             "zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez"
-        val recipient = RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+        val recipient =
+            RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
         ZIP321.request(recipient) shouldBe expected
     }
 
@@ -27,7 +29,7 @@ class ZcashSwiftPaymentUriTests : FreeSpec({
             RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
         val payment = Payment(
             recipientAddress = recipient,
-            amount = Amount(BigDecimal(1)),
+            nonNegativeAmount = NonNegativeAmount(BigDecimal(1)),
             memo = MemoBytes("This is a simple memo."),
             label = null,
             message = "Thank you for your purchase",
@@ -54,7 +56,7 @@ class ZcashSwiftPaymentUriTests : FreeSpec({
         val recipient0 = RecipientAddress("tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU")
         val payment0 = Payment(
             recipientAddress = recipient0,
-            amount = Amount.create(BigDecimal(123.456)),
+            nonNegativeAmount = NonNegativeAmount.create(BigDecimal(123.456)),
             memo = null,
             label = null,
             message = null,
@@ -65,7 +67,7 @@ class ZcashSwiftPaymentUriTests : FreeSpec({
             RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
         val payment1 = Payment(
             recipientAddress = recipient1,
-            amount = Amount.create(BigDecimal(0.789)),
+            nonNegativeAmount = NonNegativeAmount.create(BigDecimal(0.789)),
             memo = MemoBytes("This is a unicode memo ✨🦄🏆🎉"),
             label = null,
             message = null,
@@ -75,5 +77,40 @@ class ZcashSwiftPaymentUriTests : FreeSpec({
         val paymentRequest = PaymentRequest(payments = listOf(payment0, payment1))
 
         ZIP321.uriString(paymentRequest, ZIP321.FormattingOptions.UseEmptyParamIndex(omitAddressLabel = false)) shouldBe expected
+    }
+
+    "test that multiple payments can be parsed" {
+        val validURI =
+            "zcash:?address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU&amount=123.456&address.1=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amount.1=0.789&memo.1=VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok"
+
+        val recipient0 = RecipientAddress("tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU")
+        val payment0 = Payment(
+            recipientAddress = recipient0,
+            nonNegativeAmount = NonNegativeAmount.create(BigDecimal(123.456)),
+            memo = null,
+            label = null,
+            message = null,
+            otherParams = null
+        )
+
+        val recipient1 =
+            RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+        val payment1 = Payment(
+            recipientAddress = recipient1,
+            nonNegativeAmount = NonNegativeAmount.create(BigDecimal(0.789)),
+            memo = MemoBytes("This is a unicode memo ✨🦄🏆🎉"),
+            label = null,
+            message = null,
+            otherParams = null
+        )
+
+        val paymentRequest = PaymentRequest(payments = listOf(payment0, payment1))
+
+        when (val parsedRequest = ZIP321.request(validURI, null)) {
+            is ZIP321.ParserResult.SingleAddress -> fail("expected Request. got $parsedRequest")
+            is ZIP321.ParserResult.Request -> {
+                parsedRequest.paymentRequest shouldBe paymentRequest
+            }
+        }
     }
 })

--- a/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/parser/ParserTests.kt
+++ b/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/parser/ParserTests.kt
@@ -1,0 +1,43 @@
+package dev.thecodebuffet.zcash.zip321.parser
+
+import RecipientAddress
+import com.copperleaf.kudzu.parser.ParserContext
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class ParserTests : FreeSpec({
+    "Parser detects leading addresses" - {
+        "detects single recipient with leading address" {
+            val validURI = "zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez"
+            val (node, remainingText) = Parser(null).maybeLeadingAddressParse.parse(
+                ParserContext.fromString(validURI)
+            )
+
+            val recipient =
+                RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez", null)
+            remainingText.isEmpty() shouldBe true
+            node.value shouldBe IndexedParameter(0u, Param.Address(recipient))
+        }
+
+        "detects leading address with other params" {
+            val validURI = "zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?amount=1.0001"
+            val (node, remainingText) = Parser(null).maybeLeadingAddressParse.parse(
+                ParserContext.fromString(validURI)
+            )
+
+            val recipient =
+                RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez", null)
+            remainingText.isEmpty() shouldBe false
+            node.value shouldBe IndexedParameter(0u, Param.Address(recipient))
+        }
+
+        "returns null when no leading address is present" {
+            val validURI = "zcash:?amount=1.0001&address=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez"
+            val (node, remainingText) = Parser(null).maybeLeadingAddressParse.parse(
+                ParserContext.fromString(validURI)
+            )
+            remainingText.isEmpty() shouldBe false
+            node.value shouldBe null
+        }
+    }
+})

--- a/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/parser/SubParserTests.kt
+++ b/lib/src/test/kotlin/dev/thecodebuffet/zcash/zip321/parser/SubParserTests.kt
@@ -1,0 +1,401 @@
+package dev.thecodebuffet.zcash.zip321.parser
+import MemoBytes
+import NonNegativeAmount
+import OtherParam
+import Payment
+import RecipientAddress
+import com.copperleaf.kudzu.parser.ParserContext
+import dev.thecodebuffet.zcash.zip321.ZIP321
+import dev.thecodebuffet.zcash.zip321.extensions.qcharDecode
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.math.BigDecimal
+
+class SubParserTests : FreeSpec({
+    "paramindex subparser" - {
+        "parses non-zero single digit" {
+            Parser(null).parameterIndexParser
+                .parse(ParserContext.fromString("1")).first.value shouldBe 1u
+
+            Parser(null).parameterIndexParser
+                .parse(ParserContext.fromString("9")).first.value shouldBe 9u
+        }
+
+        "fails on zero single digit" {
+            shouldThrowAny {
+                Parser(null).parameterIndexParser
+                    .parse(ParserContext.fromString("0"))
+            }
+        }
+
+        "parses many digits" {
+            Parser(null).parameterIndexParser
+                .parse(ParserContext.fromString("12")).first.value shouldBe 12u
+            Parser(null).parameterIndexParser
+                .parse(ParserContext.fromString("123")).first.value shouldBe 123u
+        }
+
+        "fails on leading zero many digits" - {
+            shouldThrowAny {
+                Parser(null).parameterIndexParser
+                    .parse(ParserContext.fromString("090"))
+            }
+        }
+
+        "fails on too many digits" - {
+            shouldThrowAny {
+                Parser(null).parameterIndexParser
+                    .parse(ParserContext.fromString("19999"))
+            }
+        }
+    }
+    "Optionally IndexedParameter Name parsing" - {
+        "parses a non-indexed parameter" {
+            Parser(null).optionallyIndexedParamName
+                .parse(
+                    ParserContext.fromString("address")
+                )
+                .first
+                .value shouldBe Pair<String, UInt?>("address", null)
+        }
+        "parses a indexed parameter" {
+            Parser(null).optionallyIndexedParamName
+                .parse(
+                    ParserContext.fromString("address.123")
+                )
+                .first
+                .value shouldBe Pair<String, UInt?>("address", 123u)
+        }
+        "fails to parse a zero-index parameter" {
+            shouldThrowAny {
+                Parser(null).optionallyIndexedParamName
+                    .parse(
+                        ParserContext.fromString("address.0")
+                    )
+            }
+        }
+        "fails to parse leading zero parameter" {
+            shouldThrowAny {
+                Parser(null).optionallyIndexedParamName
+                    .parse(
+                        ParserContext.fromString("address.023")
+                    )
+            }
+        }
+
+        "fails to parse a parameter with an index greater than 9999" {
+            shouldThrowAny {
+                Parser(null).optionallyIndexedParamName
+                    .parse(
+                        ParserContext.fromString("address.19999")
+                    )
+            }
+        }
+
+        "fails to parse a paramname with invalid characters" {
+            shouldThrowAny {
+                Parser(null).optionallyIndexedParamName
+                    .parse(
+                        ParserContext.fromString("add[ress[1].1")
+                    )
+            }
+        }
+    }
+    "Query and Key parser" - {
+        "parses a query key with no index" {
+            val parsedQueryParam = Parser(null).queryKeyAndValueParser
+                .parse(
+                    ParserContext.fromString(
+                        "address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"
+                    )
+                ).first.value
+
+            parsedQueryParam.first.first shouldBe "address"
+            parsedQueryParam.first.second shouldBe null
+            parsedQueryParam.second shouldBe "tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"
+        }
+
+        "parses a query key with a valid index" {
+            val parsedQueryParam = Parser(null).queryKeyAndValueParser
+                .parse(
+                    ParserContext.fromString(
+                        "address.123=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"
+                    )
+                ).first.value
+
+            parsedQueryParam.first.first shouldBe "address"
+            parsedQueryParam.first.second shouldBe 123u
+            parsedQueryParam.second shouldBe "tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"
+        }
+
+        "fails to parse a query key with invalid index" {
+            shouldThrowAny {
+                Parser(null).queryKeyAndValueParser
+                    .parse(
+                        ParserContext.fromString(
+                            "address.00123=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"
+                        )
+                    )
+            }
+        }
+    }
+
+    "query key parsing tests" - {
+        "parser catches query qcharencoded values" {
+            Parser(null).queryKeyAndValueParser
+                .parse(
+                    ParserContext.fromString("message.1=Thank%20You%20For%20Your%20Purchase")
+                )
+                .first
+                .value shouldBe Pair(Pair("message", 1u), "Thank%20You%20For%20Your%20Purchase")
+        }
+
+        "Zcash parameter creates valid amount" {
+            val query = "amount"
+            val value = "1.00020112"
+            val index = 1u
+            val input = Pair<Pair<String, UInt?>, String>(Pair(query, index), value)
+            Parser(null).zcashParameter(input) shouldBe
+                IndexedParameter(1u, Param.Amount(amount = NonNegativeAmount(value)))
+        }
+
+        "Zcash parameter creates valid message" {
+            val query = "message"
+            val index = 1u
+            val value = "Thank%20You%20For%20Your%20Purchase"
+            val input = Pair<Pair<String, UInt?>, String>(Pair(query, index), value)
+            val qcharDecodedValue = value.qcharDecode() ?: ""
+            qcharDecodedValue shouldNotBe ""
+
+            Parser(null).zcashParameter(input) shouldBe
+                IndexedParameter(1u, Param.Message(qcharDecodedValue))
+        }
+
+        "Zcash parameter creates valid label" {
+            val query = "label"
+            val index = 1u
+            val value = "Thank%20You%20For%20Your%20Purchase"
+            val input = Pair<Pair<String, UInt?>, String>(Pair(query, index), value)
+            val qcharDecodedValue = value.qcharDecode() ?: ""
+            qcharDecodedValue shouldNotBe ""
+
+            Parser(null).zcashParameter(input) shouldBe
+                IndexedParameter(1u, Param.Label(qcharDecodedValue))
+        }
+
+        "Zcash parameter creates valid memo" {
+            val query = "memo"
+            val index = 99u
+            val value = "VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"
+            val input = Pair<Pair<String, UInt?>, String>(Pair(query, index), value)
+            val memo = MemoBytes.fromBase64URL(value)
+            Parser(null).zcashParameter(input) shouldBe
+                IndexedParameter(99u, Param.Memo(memo))
+        }
+
+        "Zcash parameter creates valid memo that contains UTF-8 characters" {
+            val query = "memo"
+            val index = 99u
+            val value = "VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok"
+            val input = Pair<Pair<String, UInt?>, String>(Pair(query, index), value)
+            Parser(null).queryKeyAndValueParser.parse(
+                ParserContext.fromString("memo.99=VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok")
+            ).first.value shouldBe input
+        }
+
+        "Zcash parameter creates safely ignored other parameter" {
+            val query = "future-binary-format"
+            val value = "VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"
+            val input = Pair<Pair<String, UInt?>, String>(Pair(query, null), value)
+            Parser(null).zcashParameter(input) shouldBe
+                IndexedParameter(0u, Param.Other(query, value))
+        }
+    }
+
+    "Parses many parameters in a row" - {
+        "Index parameters are parsed with no leading address" {
+            val remainingString = "?address=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amount=1&memo=VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg&message=Thank%20you%20for%20your%20purchase"
+
+            val recipient =
+                RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+
+            val expected = listOf(
+                IndexedParameter(0u, Param.Address(recipient)),
+                IndexedParameter(0u, Param.Amount(NonNegativeAmount("1"))),
+                IndexedParameter(0u, Param.Memo(MemoBytes.fromBase64URL("VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"))),
+                IndexedParameter(0u, Param.Message("Thank you for your purchase"))
+            )
+
+            Parser(null).parseParameters(ParserContext.fromString(remainingString), null) shouldBe expected
+        }
+    }
+
+    "Index parameters are parsed with leading address" {
+        val remainingString = "?amount=1&memo=VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg&message=Thank%20you%20for%20your%20purchase"
+
+        val recipient =
+            RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+
+        val expected = listOf(
+            IndexedParameter(0u, Param.Address(recipient)),
+            IndexedParameter(0u, Param.Amount(NonNegativeAmount("1"))),
+            IndexedParameter(0u, Param.Memo(MemoBytes.fromBase64URL("VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"))),
+            IndexedParameter(0u, Param.Message("Thank you for your purchase"))
+        )
+
+        val leadingAddress = IndexedParameter(0u, Param.Address(recipient))
+
+        Parser(null).parseParameters(ParserContext.fromString(remainingString), leadingAddress) shouldBe expected
+    }
+
+    "Duplicate Params are caught" - {
+        "Duplicate other params are detected" {
+            val params = listOf(
+                Param.Address(RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")),
+                Param.Amount(NonNegativeAmount("1")),
+                Param.Message("Thanks"),
+                Param.Label("payment"),
+                Param.Other("future", "is awesome")
+            )
+
+            params.hasDuplicateParam(Param.Other("future", "is dystopic")) shouldBe true
+        }
+
+        "Duplicate address params are detected" {
+            val params = listOf(
+                Param.Address(RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")),
+                Param.Amount(NonNegativeAmount("1")),
+                Param.Message("Thanks"),
+                Param.Label("payment"),
+                Param.Other("future", "is awesome")
+            )
+
+            params.hasDuplicateParam(Param.Address(RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez"))) shouldBe true
+        }
+    }
+
+    "Payment can be created from uniquely indexed Params" - {
+        "Payment is created from indexed parameters" {
+            val recipient = RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+                ?: error("Failed to create recipient")
+
+            val params = listOf(
+                Param.Address(recipient),
+                Param.Amount(NonNegativeAmount("1")),
+                Param.Message("Thanks"),
+                Param.Label("payment"),
+                Param.Other("future", "is awesome")
+            )
+
+            val payment = Payment.fromUniqueIndexedParameters(index = 1u, parameters = params)
+
+            payment shouldBe Payment(
+                recipientAddress = recipient,
+                nonNegativeAmount = NonNegativeAmount("1"),
+                memo = null,
+                label = "payment",
+                message = "Thanks",
+                otherParams = listOf(OtherParam("future", "is awesome"))
+            )
+        }
+
+        "duplicate addresses are detected" {
+            val shieldedRecipient =
+                RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+
+            val duplicateAddressParams: List<IndexedParameter> = listOf(
+                IndexedParameter(index = 0u, param = Param.Address(shieldedRecipient)),
+                IndexedParameter(index = 0u, param = Param.Amount(NonNegativeAmount(value = BigDecimal(1)))),
+                IndexedParameter(index = 0u, param = Param.Message("Thanks")),
+                IndexedParameter(index = 0u, param = Param.Memo(MemoBytes.fromBase64URL("VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"))),
+                IndexedParameter(index = 0u, param = Param.Label("payment")),
+                IndexedParameter(index = 0u, param = Param.Address(shieldedRecipient)),
+                IndexedParameter(index = 0u, param = Param.Other("future", "is awesome"))
+            )
+
+            shouldThrow<ZIP321.Errors> {
+                Parser(null).mapToPayments(duplicateAddressParams)
+            } shouldBe ZIP321.Errors.DuplicateParameter("address", null)
+        }
+
+        "duplicate amounts are detected" {
+            val shieldedRecipient =
+                RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+
+            val duplicateAmountParams: List<IndexedParameter> = listOf(
+                IndexedParameter(index = 0u, param = Param.Address(shieldedRecipient)),
+                IndexedParameter(index = 0u, param = Param.Amount(NonNegativeAmount(value = BigDecimal(1)))),
+                IndexedParameter(index = 0u, param = Param.Message("Thanks")),
+                IndexedParameter(index = 0u, param = Param.Memo(MemoBytes.fromBase64URL("VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"))),
+                IndexedParameter(index = 0u, param = Param.Label("payment")),
+                IndexedParameter(index = 0u, param = Param.Amount(NonNegativeAmount(value = BigDecimal(2)))),
+                IndexedParameter(index = 0u, param = Param.Other("future", "is awesome"))
+            )
+
+            shouldThrow<ZIP321.Errors> {
+                Parser(null).mapToPayments(duplicateAmountParams)
+            } shouldBe ZIP321.Errors.DuplicateParameter("amount", null)
+        }
+
+        "duplicate message are detected" {
+            val shieldedRecipient =
+                RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+
+            val duplicateParams: List<IndexedParameter> = listOf(
+                IndexedParameter(index = 0u, param = Param.Address(shieldedRecipient)),
+                IndexedParameter(index = 0u, param = Param.Amount(NonNegativeAmount(value = BigDecimal(1)))),
+                IndexedParameter(index = 0u, param = Param.Message("Thanks")),
+                IndexedParameter(index = 0u, param = Param.Memo(MemoBytes.fromBase64URL("VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"))),
+                IndexedParameter(index = 0u, param = Param.Message("Thanks")),
+                IndexedParameter(index = 0u, param = Param.Label("payment")),
+                IndexedParameter(index = 0u, param = Param.Amount(NonNegativeAmount(value = BigDecimal(2)))),
+                IndexedParameter(index = 0u, param = Param.Other("future", "is awesome"))
+            )
+
+            shouldThrow<ZIP321.Errors> {
+                Parser(null).mapToPayments(duplicateParams)
+            } shouldBe ZIP321.Errors.DuplicateParameter("message", null)
+        }
+
+        "duplicate memos are detected" {
+            val shieldedRecipient =
+                RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+
+            val duplicateParams: List<IndexedParameter> = listOf(
+                IndexedParameter(index = 0u, param = Param.Address(shieldedRecipient)),
+                IndexedParameter(index = 0u, param = Param.Memo(MemoBytes.fromBase64URL("VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"))),
+                IndexedParameter(index = 0u, param = Param.Amount(NonNegativeAmount(value = BigDecimal(1)))),
+                IndexedParameter(index = 0u, param = Param.Message("Thanks")),
+                IndexedParameter(index = 0u, param = Param.Memo(MemoBytes.fromBase64URL("VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"))),
+                IndexedParameter(index = 0u, param = Param.Label("payment")),
+                IndexedParameter(index = 0u, param = Param.Other("future", "is awesome"))
+            )
+
+            shouldThrow<ZIP321.Errors> {
+                Parser(null).mapToPayments(duplicateParams)
+            } shouldBe ZIP321.Errors.DuplicateParameter("memo", null)
+        }
+
+        "duplicate other params are detected" {
+            val shieldedRecipient =
+                RecipientAddress("ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez")
+
+            val duplicateParams: List<IndexedParameter> = listOf(
+                IndexedParameter(index = 0u, param = Param.Address(shieldedRecipient)),
+                IndexedParameter(index = 0u, param = Param.Label("payment")),
+                IndexedParameter(index = 0u, param = Param.Amount(NonNegativeAmount(value = BigDecimal(1)))),
+                IndexedParameter(index = 0u, param = Param.Message("Thanks")),
+                IndexedParameter(index = 0u, param = Param.Other("future", "is dystopian")),
+                IndexedParameter(index = 0u, param = Param.Memo(MemoBytes.fromBase64URL("VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg"))),
+                IndexedParameter(index = 0u, param = Param.Other("future", "is awesome"))
+            )
+
+            shouldThrow<ZIP321.Errors> {
+                Parser(null).mapToPayments(duplicateParams)
+            } shouldBe ZIP321.Errors.DuplicateParameter("future", null)
+        }
+    }
+})

--- a/tools/detekt.yml
+++ b/tools/detekt.yml
@@ -10,6 +10,15 @@ naming:
 
 style:
   active: true
+  MaxLineLength:
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
+    excludeRawStrings: true
+
   ForbiddenComment:
     active: true
     comments:


### PR DESCRIPTION
closes #25 

This Feature adds ZIP-321 parsing support to the library.

It uses [Kudzu](https://copper-leaf.github.io/kudzu/), a parser combinator library inspired in Parsecs.

The ZIP-321 provides no address validation (yet). This is left to the caller to provide lambdas that do so as
they please.

