### PR TITLE
[#34] Replace `removeFirst` with `removeAt`

### DIFF
--- a/lib/src/main/kotlin/org/zecdev/zip321/Render.kt
+++ b/lib/src/main/kotlin/org/zecdev/zip321/Render.kt
@@ -119,9 +119,9 @@ object Render {
                 startIndex,
                 omittingFirstAddressLabel
             )
-            payments.removeFirst()
 
             if (payments.isNotEmpty()) {
+                payments.removeAt(0)
                 result += "&"
             }
         }

--- a/lib/src/main/kotlin/org/zecdev/zip321/Render.kt
+++ b/lib/src/main/kotlin/org/zecdev/zip321/Render.kt
@@ -119,9 +119,10 @@ object Render {
                 startIndex,
                 omittingFirstAddressLabel
             )
-
             if (payments.isNotEmpty()) {
                 payments.removeAt(0)
+            }
+            if (payments.isNotEmpty()) {
                 result += "&"
             }
         }


### PR DESCRIPTION
- The removal is also moved under the empty collection check to avoid an empty collection removal exception if that case could happen
- Closes #34 